### PR TITLE
[FEAT] Update api

### DIFF
--- a/person_image_segmentation/api/app.py
+++ b/person_image_segmentation/api/app.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, UploadFile, File, HTTPException, Depends
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from fastapi.responses import FileResponse
+from starlette.staticfiles import StaticFiles
 from pathlib import Path
 from PIL import Image
 import os
@@ -45,6 +46,9 @@ def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security)):
         )
     return token
 
+print(str(REPO_PATH) + "/static")
+app.mount("/static", StaticFiles(directory = str(REPO_PATH) + "/static", html=True), name = "static")
+
 # Ruta para servir el favicon
 @app.get("/favicon.ico", include_in_schema=True)
 async def favicon():
@@ -65,7 +69,7 @@ async def predict_mask(file: UploadFile = File(...), token: str = Depends(verify
             shutil.copyfileobj(file.file, buffer)
 
         img = Image.open(img_path)
-        print(img.format)
+      
         if img.format != 'JPEG':
             img = img.convert('RGB')  # Convertir a RGB
             jpg_path = f"temp_{os.path.splitext(file.filename)[0]}.jpg"  # Nueva ruta con extensión JPG
@@ -101,7 +105,7 @@ async def predict_mask(file: UploadFile = File(...), token: str = Depends(verify
 
                 # Convertir la máscara a imagen y devolverla
                 im_to_save = Image.fromarray(pred_mask)
-                im_to_save.save(f"pred_{file.filename}")
+                im_to_save.save(str(REPO_PATH) + "/static/"+f"pred_{file.filename}")
 
                 # Eliminar archivo temporal
                 os.remove(img_path)

--- a/person_image_segmentation/api/app.py
+++ b/person_image_segmentation/api/app.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, UploadFile, File, HTTPException, Depends
+from fastapi import FastAPI, UploadFile, File, HTTPException, Depends, BackgroundTasks
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from fastapi.responses import FileResponse
 from starlette.staticfiles import StaticFiles
@@ -6,16 +6,20 @@ from pathlib import Path
 from PIL import Image
 import os
 import torch
+import time
 import numpy as np
 import shutil
 from ultralytics import YOLO
 from dotenv import load_dotenv
+from threading import Thread
 
 from person_image_segmentation.api.schema import (
     PredictionResponse,
     ErrorResponse,
     RootResponse,
 )
+
+from datetime import datetime
 
 # Load Kaggle credentials
 load_dotenv()
@@ -53,10 +57,41 @@ app.mount("/static", StaticFiles(directory = str(REPO_PATH) + "/static", html=Tr
 async def favicon():
     return FileResponse(str(REPO_PATH) + "/static/favicon.ico")  # Ruta al archivo favicon.ico
 
+
+from threading import Thread
+
+# Función para limpiar imágenes más antiguas de una hora
+def clean_old_images():
+    now = time.time()
+    time_ago = now - 600  # Cada 10 mins
+
+    for file in Path(str(REPO_PATH) + "/static").iterdir():
+        if file.name != "favicon.ico" and file.is_file():
+            # Verificar la última modificación del archivo
+            if file.stat().st_mtime < time_ago:
+                try:
+                    file.unlink()  # Eliminar el archivo
+                    print(f"File {file.name} deleted!")
+                except Exception as e:
+                    print(f"Failed to delete {file.name}: {str(e)}")
+
+# Función para ejecutar la limpieza periódicamente
+def schedule_cleaning_task():
+    while True:
+        clean_old_images()
+        time.sleep(60)  # Ejecutar cada 60 segundos 
+
+# Configurar la ejecución de la tarea periódica en el evento de inicio
+@app.on_event("startup")
+async def startup_event():
+    cleaning_thread = Thread(target=schedule_cleaning_task, daemon=True)
+    cleaning_thread.start()
+
 # Ruta base
 @app.get("/", response_model=RootResponse)
 def read_root():
     return RootResponse(message="API para hacer predicciones con YOLO")
+
 
 # Ruta para hacer predicciones
 @app.post("/predict/", response_model=PredictionResponse, responses={400: {"model": ErrorResponse}})
@@ -102,14 +137,16 @@ async def predict_mask(file: UploadFile = File(...), token: str = Depends(verify
                         if pred_mask[x][y] > 0:
                             pred_mask[x][y] = 255
 
+                # Generar el timestamp
+                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
                 # Convertir la máscara a imagen y devolverla
                 im_to_save = Image.fromarray(pred_mask)
-                im_to_save.save(str(REPO_PATH) + "/static/"+f"pred_{file.filename}")
+                im_to_save.save(str(REPO_PATH) + "/static/"+f"pred_{timestamp}_{file.filename}")
 
                 # Eliminar archivo temporal
                 os.remove(img_path)
 
-                return PredictionResponse(filename=f"pred_{file.filename}", message="Prediction complete!")
+                return PredictionResponse(filename=f"pred_{timestamp}_{file.filename}", message="Prediction complete!")
             except Exception as e:
                 return ErrorResponse(error=str(e))
 

--- a/person_image_segmentation/api/app.py
+++ b/person_image_segmentation/api/app.py
@@ -46,7 +46,6 @@ def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security)):
         )
     return token
 
-print(str(REPO_PATH) + "/static")
 app.mount("/static", StaticFiles(directory = str(REPO_PATH) + "/static", html=True), name = "static")
 
 # Ruta para servir el favicon


### PR DESCRIPTION
## What
This PR introduces two main changes:
- Configures the FastAPI application to serve static files by mounting the /static directory with support for HTML file serving. This allows the application to correctly handle requests for static assets like images in the static directory.
- Adds a background task that runs periodically to delete prediction files in the static folder that are older than 10 minutes. The cleanup process starts automatically when the application launches, ensuring regular maintenance of the static directory.

## Why
- Enabling static file serving is necessary for providing access to files that are required by the client, such as images generated by the prediction process. Adding HTML support ensures that HTML files can be served directly if needed, improving flexibility for the application's content delivery.
- Prediction files can accumulate in the static folder over time, increasing storage usage and potentially impacting server performance. By automatically deleting files older than 10 minutes, the server maintains optimal performance and ensures that the static folder contains only recent prediction results.