### PR TITLE
[FEAT] Solve errors in API for good error reporting

### DIFF
--- a/person_image_segmentation/api/app.py
+++ b/person_image_segmentation/api/app.py
@@ -93,7 +93,7 @@ app = FastAPI(
     lifespan=lifespan
 )
 
-@app.get("/favicon.ico", include_in_schema=True)
+@app.get("/favicon.ico", tags=["General"], include_in_schema=True)
 async def favicon():
     """
     Serves the favicon.ico file.
@@ -189,7 +189,9 @@ async def _predict_mask(file: UploadFile = File(...), token: str = Depends(verif
 
         return response
     except Exception as e:
-        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(e)) from e
+        if hasattr(e, 'status_code'):
+            raise HTTPException(status_code=e.status_code, detail=e.detail) from e
+        raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=str(e)) from e
     finally:
         # Make sure to delete the temporary file
         if os.path.exists(img_path):
@@ -260,7 +262,9 @@ async def _predict_mask_with_emissions(
             message="Prediction complete with energy tracking!"
             )
     except Exception as e:
-        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(e)) from e
+        if hasattr(e, 'status_code'):
+            raise HTTPException(status_code=e.status_code, detail=e.detail) from e
+        raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=str(e)) from e
     finally:
         # Make sure to delete the temporary file
         if os.path.exists(img_path):

--- a/person_image_segmentation/utils/api_utils.py
+++ b/person_image_segmentation/utils/api_utils.py
@@ -74,4 +74,6 @@ def predict_mask_function(
         return PredictionResponse(filename=output_filename, message="Prediction complete!")
 
     except Exception as e:
+        if hasattr(e, 'status_code'):
+            raise HTTPException(status_code=e.status_code, detail=e.detail) from e
         raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=str(e)) from e

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -267,7 +267,7 @@ def test_predict_mask_with_emissions_with_no_existing_file(client, payload):
     )
 
     # As there is no HTTPStatus attribute for this code, we use the code directly
-    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
 
 def test_predict_with_emissions_non_jpeg_image(client, non_jpeg_payload):
     """


### PR DESCRIPTION
### What is changing

Now errors are reported in a chain in such a way that there is no concatenation of errors, but the error flows through the traceback to be reported.

### Why

With the previous implementation, more than one error could arise at the same time, now, if some inner function raises an `HTTPException`, this `HTTPException` flows to the reported error to the user.